### PR TITLE
try lint stage on main branch

### DIFF
--- a/.github/workflows/build-lint.yaml
+++ b/.github/workflows/build-lint.yaml
@@ -24,7 +24,7 @@ jobs:
 
   lint:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/lint.yaml@self-hosted-runner
+    uses: scientist-softserv/actions/.github/workflows/lint.yaml@main
     with:
       worker: true
       # tag: deca90d9


### PR DESCRIPTION
Lint stage failing when using the shared runner branch. Trying the main branch of actions until actions library is updated.