### PR TITLE
Point actions at tag instead of main

### DIFF
--- a/.github/workflows/build-lint.yaml
+++ b/.github/workflows/build-lint.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    uses: scientist-softserv/actions/.github/workflows/build.yaml@arm-y_of_one
+    uses: scientist-softserv/actions/.github/workflows/build.yaml@v0.0.4
     secrets: inherit
     with:
       worker: true
@@ -25,7 +25,7 @@ jobs:
 
   lint:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/lint.yaml@main
+    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.4
     with:
       worker: true
       # tag: deca90d9

--- a/.github/workflows/build-lint.yaml
+++ b/.github/workflows/build-lint.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    uses: scientist-softserv/actions/.github/workflows/build.yaml@v0.0.4
+    uses: scientist-softserv/actions/.github/workflows/build.yaml@arm-y_of_one
     secrets: inherit
     with:
       worker: true
@@ -25,7 +25,7 @@ jobs:
 
   lint:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.4
+    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.3
     with:
       worker: true
       # tag: deca90d9

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   call-workflow:
-    uses: scientist-softserv/actions/.github/workflows/deploy.yaml@main
+    uses: scientist-softserv/actions/.github/workflows/deploy.yaml@v0.0.4
     secrets: inherit
     with:
       k8s-release-name: ${{ inputs.environment }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   call-workflow:
-    uses: scientist-softserv/actions/.github/workflows/deploy.yaml@v0.0.4
+    uses: scientist-softserv/actions/.github/workflows/deploy.yaml@v0.0.3
     secrets: inherit
     with:
       k8s-release-name: ${{ inputs.environment }}


### PR DESCRIPTION
This is to prevent future merges into the main branch from breaking builds that are working in this repo