### PR TITLE
revert helm chart update until we can troubleshoot failure

### DIFF
--- a/bin/helm_deploy
+++ b/bin/helm_deploy
@@ -27,7 +27,7 @@ filemtime=`date -r hyrax "+%s"`
 currtime=`date +%s`
 diff=$(( (currtime - filemtime) / 86400 ))
 if [ ! -d "hyrax" ] || [ $diff -gt 0 ]; then
-  helm pull oci://ghcr.io/samvera/charts/hyrax --version 2.0.0 --untar --untardir charts
+  helm pull oci://ghcr.io/samvera/charts/hyrax --version 1.3.0 --untar --untardir charts
   helm repo update
 else
   echo 'hyrax chart downloaded today, skipping'


### PR DESCRIPTION
In case of need for deploy, reverting helm chart update until we have a chance to troubleshoot issue with worker.