### PR TITLE
Updates to v5 but on githubs runners

### DIFF
--- a/.github/workflows/build-lint.yaml
+++ b/.github/workflows/build-lint.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    uses: scientist-softserv/actions/.github/workflows/build.yaml@arm-y_of_one
+    uses: scientist-softserv/actions/.github/workflows/build.yaml@v005-but-on-github-runners
     secrets: inherit
     with:
       worker: true
@@ -25,7 +25,7 @@ jobs:
 
   lint:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.3
+    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v005-but-on-github-runners
     with:
       worker: true
       # tag: deca90d9


### PR DESCRIPTION
Let see what happens? Updates to v5 but on githubs runners

Its free GH Actions on all public repositories :)

