### PR TITLE
adds collection id to admin collection show page

### DIFF
--- a/app/views/hyrax/dashboard/collections/show.html.erb
+++ b/app/views/hyrax/dashboard/collections/show.html.erb
@@ -10,6 +10,7 @@
   <section class="panel panel-default collections-panel-wrapper admin-show-page">
     <div class="panel-heading">
       <%= render 'collection_title', presenter: @presenter %>
+      <strong>Collection ID: </strong><%= @presenter.id %>
     </div>
 
     <div class="panel-body">


### PR DESCRIPTION
Ref: #220 
Adds the Collection ID to the Admin Collection Show page
<img width="1339" alt="Screenshot 2023-01-10 at 12 36 53 PM" src="https://user-images.githubusercontent.com/18175797/211658234-cab0798f-15ad-4679-9acb-92469f739ce6.png">
