### PR TITLE
Bring back the UV

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Atla staff use this repository as their digital library.
   - Hyrax 2.3.3
 
 ### Important URL's
-- Local site: http://localhost:3000
-  - There is no "admin" link so you must go to http://localhost:3000/dashboard to access the backend
+- Local site: http://atla.test
+  - There is no "admin" link so you must go to http:///atla.test/dashboard to access the backend
 - Staging site: http://dl-staging.atla.com
 - Production site:
 - Solr:
@@ -52,7 +52,7 @@ cd atla_digital_library
 sc up
 ```
 
-The app should now be available at http://localhost:3000.
+The app should now be available at http://atla.test.
 
 #### Run migrations and seed the database
 On the first run, you may need to run some setup:
@@ -74,6 +74,18 @@ In a new tab/window:
 ```
 sc be rails spec
 ```
+
+## Troubleshooting
+- if you see the following error: `mesg: ttyname failed: Inappropriate ioctl for device` and a list of files that already exist, for example `cp: cannot create regular file './public/uv/dist/lib/p-p4r1bdpj.system.entry.js': File exists`
+  - run `yarn` (in local shell, not inside container)
+
+- If you `rails db:seed` will not run, or you get the following bulkrax error when trying to edit an importer: `Faraday::ConnectionFailed in Bulkrax::Importers::Edit`
+  - run `dc restart fcrepo`
+
+- If you are not able to run the seeds/not able to see the seeded importer, run:
+  - `rails hyrax:default_collection_types:create`
+  - `rails hyrax:default_admin_set:create`
+  - `rails db:seed`
 
 ## Statistics Not Updating
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Atla staff use this repository as their digital library.
   - Hyrax 2.3.3
 
 ### Important URL's
-- Local site: http://atla.test
-  - There is no "admin" link so you must go to http:///atla.test/dashboard to access the backend
+- Local site: http://atla.test (http://localhost:3000/ if not using dory)
+  - There is no "admin" link so you must go to http://atla.test/dashboard (or http://localhost:3000/dashboard if not using dory) to access the backend
 - Staging site: http://dl-staging.atla.com
 - Production site:
 - Solr:

--- a/config/initializers/iiif_url.rb
+++ b/config/initializers/iiif_url.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Rails.application.config.iiif_url = ENV['IIIF_URL'] || ''

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,6 @@ x-app: &app
     - assets:/app/samvera/hyrax-webapp/public/assets
     - cache:/app/samvera/hyrax-webapp/tmp/cache
     - node:/data/node_modules
-    - uv:/app/samvera/hyrax-webapp/public/uv
     - .:/app/samvera/hyrax-webapp
 
 services:
@@ -102,4 +101,3 @@ volumes:
   assets:
   cache:
   node:
-  uv:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "universalviewer": "^3.0.36"
   },
   "scripts": {
-    "preinstall": "rm -rf /app/samvera/hyrax-webapp/public/uv/*",
+    "preinstall": "rm -rf ./public/uv",
     "postinstall": "yarn run uv-install && yarn run uv-config",
     "uv-install": "cp -r ./node_modules/universalviewer/dist ./public/uv",
     "uv-config": "cp ./config/uv/uv.html ./public/uv/uv.html & cp ./config/uv/uv-config.json ./public/uv/"


### PR DESCRIPTION
# Summary
fixes the display of the Universal Viewer

## Related
#249 

## Notes
- reverts several changes to `package.json` & `docker-compose.yml` from [this commit](https://github.com/scientist-softserv/atla_digitial_library/commit/7c23764aaaef36e8d6941a51e8d14d77a9be59b9)- this allowed the public folder to be found again
- requesting review on this from Rob or @aprilrieger since the changes that needed to be reverted were originally made on [this PR](https://github.com/scientist-softserv/atla_digitial_library/pull/247/files)
- needed to also add the initializer file mentioned in [these docs ](https://playbook-staging.notch8.com/en/samvera/universal-viewer/uv-in-blacklight)in order to bring back the content from the UV

## Screenshot
<img width="1363" alt="image" src="https://user-images.githubusercontent.com/73361970/229612560-8f353cf8-402f-4994-8620-f14cb268e7af.png">


## Acceptance Criteria
- [ ] UV displays for works that should have a UV

## Testing Instructions
1. Create a work
2. On the work-edit form, select "Additional Fields"
3. Check the box for "Use IIIF Viewer" 
<img width="500" alt="image" src="https://user-images.githubusercontent.com/73361970/229613572-4ef78a4b-b612-4f82-a3af-9ea38cbc6e60.png">
4. Select a resource type of "Image"
5. Navigate to the work-show page for that work and check that the IIIF viewer works 
