### PR TITLE
17 and 202 thumbnail issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ Atla staff use this repository as their digital library.
   - Hyrax 2.3.3
 
 ### Important URL's
-- Local site: http://localhost:3000
-  - There is no "admin" link so you must go to http://localhost:3000/dashboard to access the backend
+- Local site
+  - http://atla.test
+  - Without dory: localhost:3000
+  - There is no "admin" link so you must go to http://atla.test/dashboard (or http://localhost:3000/dashboard if not using dory) to access the backend
 - Staging site: http://dl-staging.atla.com
 - Production site:
 - Solr:

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -17,13 +17,15 @@ class WorkIndexer < Hyrax::WorkIndexer
     super.tap do |solr_doc|
       # rubocop:disable Layout/LineLength
       # make sure thumbnails are being indexed when they exist. only replace thumbs for these worktypes if they have the default thumbnail
-      if object.thumbnail_url.empty?
-        if (object.thumbnail&.video? ||
-            object.resource_type&.include?('MovingImage') ||
-            object.types&.include?('Moving Image'))
+      if object.thumbnail_id.blank?
+        if object.thumbnail&.video? ||
+           object.resource_type&.include?('MovingImage') ||
+           object.types&.include?('Moving Image')
           # rubocop:enable Layout/LineLength
           solr_doc['thumbnail_path_ss'] = ActionController::Base.helpers.asset_path('video.png')
-        elsif object.thumbnail&.audio? || object.resource_type&.include?('Sound') || object.types&.include?('Sound')
+        elsif object.thumbnail&.audio? ||
+              object.resource_type&.include?('Sound') ||
+              object.types&.include?('Sound')
           solr_doc['thumbnail_path_ss'] = ActionController::Base.helpers.asset_path('audio.png')
         elsif object.thumbnail&.mime_type == 'text/html'
           solr_doc['thumbnail_path_ss'] = ActionController::Base.helpers.asset_path('html.png')

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -1,3 +1,4 @@
+# OVERRIDE Hyrax 2.6.0 to bring back in thumbnail indexing functionality from /services/hyrax/indexes_thumbnails.rb
 # Generated via
 #  `rails generate hyrax:work Work`
 class WorkIndexer < Hyrax::WorkIndexer
@@ -11,18 +12,22 @@ class WorkIndexer < Hyrax::WorkIndexer
   # this behavior
   include Hyrax::IndexesLinkedMetadata
 
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def generate_solr_document
     super.tap do |solr_doc|
       # rubocop:disable Layout/LineLength
-      if object.thumbnail&.video? || object.resource_type&.include?('MovingImage') || object.types&.include?('Moving Image')
-        # rubocop:enable Layout/LineLength
-        solr_doc['thumbnail_path_ss'] = ActionController::Base.helpers.asset_path('video.png')
-      elsif object.thumbnail&.audio? || object.resource_type&.include?('Sound') || object.types&.include?('Sound')
-        solr_doc['thumbnail_path_ss'] = ActionController::Base.helpers.asset_path('audio.png')
-      elsif object.thumbnail&.mime_type == 'text/html'
-        solr_doc['thumbnail_path_ss'] = ActionController::Base.helpers.asset_path('html.png')
+      # make sure thumbnails are being indexed when they exist. only replace thumbs for these worktypes if they have the default thumbnail
+      if object.thumbnail_url.empty?
+        if (object.thumbnail&.video? ||
+            object.resource_type&.include?('MovingImage') ||
+            object.types&.include?('Moving Image'))
+          # rubocop:enable Layout/LineLength
+          solr_doc['thumbnail_path_ss'] = ActionController::Base.helpers.asset_path('video.png')
+        elsif object.thumbnail&.audio? || object.resource_type&.include?('Sound') || object.types&.include?('Sound')
+          solr_doc['thumbnail_path_ss'] = ActionController::Base.helpers.asset_path('audio.png')
+        elsif object.thumbnail&.mime_type == 'text/html'
+          solr_doc['thumbnail_path_ss'] = ActionController::Base.helpers.asset_path('html.png')
+        end
       end
       if object.transcript_url
         begin
@@ -36,6 +41,5 @@ class WorkIndexer < Hyrax::WorkIndexer
       end
     end
   end
-  # rubocop:enable Metrics/PerceivedComplexity
-  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
 end


### PR DESCRIPTION
# Summary
Makes default thumbnails only apply for works with work types Moving Image & Sound that have no specified thumbnail

# Related
#17 #202 

# Previous behavior
thumbnails were being replaced with default video (Moving Image), audio (Sound), even when the work was specified to have a thumbnail

# Expected behavior after these changes
Moving Image and Sound works with specified thumbnails (thumbnails added to the `remote_files` column in a bulkrax import) will import with that thumbnail

# Screenshots
<img width="1347" alt="image" src="https://user-images.githubusercontent.com/73361970/231524130-ab58e571-4b0e-4fca-bf38-3daffef05dc5.png">

# Notes
Will likely require a reindex of existing works in atla staging/prod to make sure the correct thumbnails are rendered. Previously on this ticket, rob had said this would not apply to previously imported works but would apply to future imported works

If re-indexing does not work, we may need to re-run importers for the following collections (these were recently listed on ticket #202):
https://dl.atla.com/collections/sermons-of-the-reverend-dr-william-augustus-jones-jr
https://dl.atla.com/concern/works/jm215126b?locale=en
 https://dl.atla.com/collections/david-l-smiley-papers?locale=en&page=3&per_page=100&sort=score+desc%2C+system_create_dtsi+desc
 [ttps://dl.atla.com/collections/a-life-apart-hasidism-in-america](https://dl.atla.com/collections/a-life-apart-hasidism-in-america)
 
 This should also apply for html icons- BUT, i was not able to test this. Need a csv that has an example html work

# Testing instructions
1. Download the following test csv as a csv: https://docs.google.com/spreadsheets/d/1D2HqvPJhDKorqtK8pz8UQzPc-fmWlcnSeeTPKXmD_DQ/edit#gid=0
2. navigate to /dashboard
3. click "importers" on the left panel
4.  Upload the csv to bulkrax - choose the csv parser
5. Make sure the default sound and default video icons show up for the sound and moving image works with NO thumbnail
6. Check that adventure time thumbnails show up for the sound and moving image that are titled "with thumbnail"
7. The work titled "text - no thumbnail" should have the default box thumbnail, and the text & article "with thumbnail" should both have adventure time thumbnails