### PR TITLE
222 missing thumbnails

### DIFF
--- a/lib/tasks/thumbnails.rake
+++ b/lib/tasks/thumbnails.rake
@@ -45,7 +45,7 @@ namespace :atla do
     puts "******************************"
   end
 
-  desc 'fix the thumbnail paths for a given work id'
+  desc 'fix the thumbnail path for a given work id'
   # rake atla:update_thumbnail_path_for_one_work[work_id]
   task :update_thumbnail_path_for_one_work, [:work_id] => [:environment] do |t, args|
     begin

--- a/lib/tasks/thumbnails.rake
+++ b/lib/tasks/thumbnails.rake
@@ -5,8 +5,8 @@ namespace :atla do
     # the path should actually point to the "downloads" folder.
     return unless solr_doc['thumbnail_path_ss'].include? 'assets'
 
-    work.thumbnail = ActiveFedora::Base.find work.thumbnail_id
-    work.save
+    work.thumbnail = work.thumbnail_id ? ActiveFedora::Base.find(work.thumbnail_id) : work.file_sets.first
+    work.save if work.thumbnail.present?
   end
 
   desc 'fix the thumbnail paths for all works in the database'

--- a/lib/tasks/thumbnails.rake
+++ b/lib/tasks/thumbnails.rake
@@ -49,7 +49,7 @@ namespace :atla do
   # rake atla:update_thumbnail_path_for_one_work[work_id]
   task :update_thumbnail_path_for_one_work, [:work_id] => [:environment] do |t, args|
     begin
-      work = ActiveFedora::Base.find work_id
+      work = ActiveFedora::Base.find args[:work_id]
       next if work.nil?
 
       update_thumbnail_reference(work)

--- a/lib/tasks/thumbnails.rake
+++ b/lib/tasks/thumbnails.rake
@@ -28,7 +28,7 @@ namespace :atla do
 
   desc 'fix the thumbnail paths for the given bulkrax importer id'
   # rake atla:update_thumbnail_paths_per_bulkrax_importer[bulkrax_id]
-  task :update_thumbnail_paths_per_bulkrax_importer, [:bulkrax_id] => [:environment, ] do |t, args|
+  task :update_thumbnail_paths_per_bulkrax_importer, [:bulkrax_id] => [:environment] do |t, args|
     begin
       Bulkrax::Importer.find(args[:bulkrax_id]).entries.each do |entry|
         puts "entry.id:: #{entry.id}"

--- a/lib/tasks/thumbnails.rake
+++ b/lib/tasks/thumbnails.rake
@@ -31,13 +31,9 @@ namespace :atla do
   task :update_thumbnail_paths_per_bulkrax_importer, [:bulkrax_id] => [:environment] do |t, args|
     begin
       Bulkrax::Importer.find(args[:bulkrax_id]).entries.each do |entry|
-        puts "entry.id:: #{entry.id}"
-        # find the related works for those entries
         work = Work.where(identifier: entry.identifier).first
         next if work.nil?
-        # next unless SolrDocument.find(work.id)['thumbnail_path_ss'].include? 'assets'
 
-        # puts "***** updating the thumbnail for #{cc}.id: #{work.id}"
         update_thumbnail_reference(work)
       end
     rescue => e

--- a/lib/tasks/thumbnails.rake
+++ b/lib/tasks/thumbnails.rake
@@ -1,0 +1,51 @@
+# coding: utf-8
+namespace :atla do
+  def update_thumbnail_reference work
+    solr_doc = SolrDocument.find(work.id)
+    # the path should actually point to the "downloads" folder.
+    return unless solr_doc['thumbnail_path_ss'].include? 'assets'
+
+    work.thumbnail = ActiveFedora::Base.find work.thumbnail_id
+    work.save
+  end
+
+  desc 'fix the thumbnail paths for all works in the database'
+  task update_all_thumbnail_paths: [:environment] do
+    Hyrax.config.curation_concerns.each do |cc|
+      cc.all.each do |work|
+        begin
+          update_thumbnail_reference(work)
+        rescue => e
+          puts "******** update_all_thumbnail_paths error: #{e} ********"
+        end
+      end
+
+      puts "******************************"
+      puts "THUMBNAIL UPDATES COMPLETE."
+      puts "******************************"
+    end
+  end
+
+  desc 'fix the thumbnail paths for the given bulkrax importer id'
+  # rake atla:update_thumbnail_paths_per_bulkrax_importer[bulkrax_id]
+  task :update_thumbnail_paths_per_bulkrax_importer, [:bulkrax_id] => [:environment, ] do |t, args|
+    begin
+      Bulkrax::Importer.find(args[:bulkrax_id]).entries.each do |entry|
+        puts "entry.id:: #{entry.id}"
+        # find the related works for those entries
+        work = Work.where(identifier: entry.identifier).first
+        next if work.nil?
+        # next unless SolrDocument.find(work.id)['thumbnail_path_ss'].include? 'assets'
+
+        # puts "***** updating the thumbnail for #{cc}.id: #{work.id}"
+        update_thumbnail_reference(work)
+      end
+    rescue => e
+      puts "******** update_thumbnail_paths_per_bulkrax_importer error: #{e} ********"
+    end
+
+    puts "******************************"
+    puts "THUMBNAIL UPDATES COMPLETE."
+    puts "******************************"
+  end
+end

--- a/lib/tasks/thumbnails.rake
+++ b/lib/tasks/thumbnails.rake
@@ -44,4 +44,21 @@ namespace :atla do
     puts "THUMBNAIL UPDATES COMPLETE."
     puts "******************************"
   end
+
+  desc 'fix the thumbnail paths for a given work id'
+  # rake atla:update_thumbnail_path_for_one_work[work_id]
+  task :update_thumbnail_path_for_one_work, [:work_id] => [:environment] do |t, args|
+    begin
+      work = ActiveFedora::Base.find work_id
+      next if work.nil?
+
+      update_thumbnail_reference(work)
+    rescue => e
+      puts "******** update_thumbnail_path_for_one_work error: #{e} ********"
+    end
+
+    puts "******************************"
+    puts "THUMBNAIL UPDATE COMPLETE."
+    puts "******************************"
+  end
 end


### PR DESCRIPTION
ref: #222 

# story
looking at the solr document for https://dl.atla.com/concern/works/sj139j45m (missing the thumbnail), the `thumbnail_path_ss` value points at a string in the "assets" path. whereas, the solr document for https://dl.atla.com/concern/works/gh93hf179 (has a thumbnail) has a `thumbnail_path_ss` value that points towards "downloads". we believe that's the issue.

it seems like somewhere during the process of creating the work in hyrax, a race condition or something happens and the thumbnail isn't set properly. 

<details>
<summary>"sj139j45m" solr doc</summary>

```sh
 @_source=
  {"system_create_dtsi"=>"2023-01-03T22:14:41Z",
   "system_modified_dtsi"=>"2023-01-03T22:15:20Z",
   "has_model_ssim"=>["Work"],
   "id"=>"sj139j45m",
   "accessControl_ssim"=>["8106bc42-c5a6-43c5-8d2a-40070dd90692"],
   "hasRelatedMediaFragment_ssim"=>["8s45qs24x"],
   "hasRelatedImage_ssim"=>["8s45qs24x"],
   "depositor_ssim"=>["rob@notch8.com"],
   "depositor_tesim"=>["rob@notch8.com"],
   "title_tesim"=>["Correspondence, 1831-1837, 71"],
   "date_uploaded_dtsi"=>"2023-01-03T22:14:41Z",
   "date_modified_dtsi"=>"2023-01-03T22:14:41Z",
   "isPartOf_ssim"=>["admin_set/default"],
   "contributing_institution_tesim"=>["Duke University Libraries"],
   "date_tesim"=>["1831/1837"],
   "format_original_tesim"=>["Correspondence"],
   "types_tesim"=>["Text"],
   "subject_tesim"=>["Wilberforce, William, 1759-1833"],
   "rights_statement_tesim"=>["https://creativecommons.org/publicdomain/mark/1.0"],
   "identifier_tesim"=>["https://idn.duke.edu/ark:/87924/r4w952j42"],
   "ancestor_collection_ids_tesim"=>["ww72bj826", "h989rb20j"],
   "ancestor_relationships_tesim"=>["ww72bj826:h989rb20j"],
   "thumbnail_path_ss"=>"/assets/work-e9cc53840eb6036829765eb10a353810f3c1e4ded4b21be2823c053c8cfb74ea.png",
   "suppressed_bsi"=>false,
   "actionable_workflow_roles_ssim"=>["admin_set/default-default-managing", "admin_set/default-default-approving", "admin_set/default-default-depositing"],
   "workflow_state_name_ssim"=>["deposited"],
   "member_ids_ssim"=>["8s45qs24x"],
   "member_of_collections_ssim"=>["William Wilberforce Papers, 1782-1837 and undated"],
   "member_of_collection_ids_ssim"=>["h989rb20j"],
   "file_set_ids_ssim"=>["8s45qs24x"],
   "visibility_ssi"=>"open",
   "admin_set_tesim"=>["Default Admin Set"],
   "human_readable_type_tesim"=>["Work"],
   "read_access_group_ssim"=>["public"],
   "edit_access_group_ssim"=>["admin"],
   "edit_access_person_ssim"=>["rob@notch8.com"],
   "nesting_collection__ancestors_ssim"=>["ww72bj826", "ww72bj826/h989rb20j"],          
   "nesting_collection__parent_ids_ssim"=>["h989rb20j"],
   "nesting_collection__pathnames_ssim"=>["ww72bj826/h989rb20j/sj139j45m"],
   "nesting_collection__deepest_nested_depth_isi"=>3,
   "_version_"=>1754041467645460480,
   "timestamp"=>"2023-01-03T22:18:17.605Z"}
```
</details>


<details>
<summary>"gh93hf179" solr doc</summary>

```sh
 @_source=
  {"system_create_dtsi"=>"2023-01-03T22:14:59Z",
   "system_modified_dtsi"=>"2023-01-03T22:15:54Z",
   "has_model_ssim"=>["Work"],
   "id"=>"gh93hf179",
   "accessControl_ssim"=>["3f425af3-3063-4b9d-8e5f-7b4dac4f2e32"],
   "hasRelatedMediaFragment_ssim"=>["xd07h967j"],
   "hasRelatedImage_ssim"=>["xd07h967j"],
   "depositor_ssim"=>["rob@notch8.com"],
   "depositor_tesim"=>["rob@notch8.com"],
   "title_tesim"=>["Correspondence, 1831-1837, 72"],
   "date_uploaded_dtsi"=>"2023-01-03T22:14:58Z",
   "date_modified_dtsi"=>"2023-01-03T22:14:58Z",
   "isPartOf_ssim"=>["admin_set/default"],
   "contributing_institution_tesim"=>["Duke University Libraries"],
   "date_tesim"=>["1831/1837"],
   "format_original_tesim"=>["Correspondence"],
   "types_tesim"=>["Text"],
   "subject_tesim"=>["Wilberforce, William, 1759-1833"],
   "rights_statement_tesim"=>["https://creativecommons.org/publicdomain/mark/1.0"],
   "identifier_tesim"=>["https://idn.duke.edu/ark:/87924/r4b56g169"],
   "ancestor_collection_ids_tesim"=>["ww72bj826", "h989rb20j"],
   "ancestor_relationships_tesim"=>["ww72bj826:h989rb20j"],
   "thumbnail_path_ss"=>"/downloads/xd07h967j?file=thumbnail",
   "suppressed_bsi"=>false,
   "actionable_workflow_roles_ssim"=>["admin_set/default-default-managing", "admin_set/default-default-approving", "admin_set/default-default-depositing"],
   "workflow_state_name_ssim"=>["deposited"],
   "member_ids_ssim"=>["xd07h967j"],
   "member_of_collections_ssim"=>["William Wilberforce Papers, 1782-1837 and undated"],
   "member_of_collection_ids_ssim"=>["h989rb20j"],
   "file_set_ids_ssim"=>["xd07h967j"],
   "visibility_ssi"=>"open",
   "admin_set_tesim"=>["Default Admin Set"],
   "human_readable_type_tesim"=>["Work"],
   "read_access_group_ssim"=>["public"],
   "edit_access_group_ssim"=>["admin"],
   "edit_access_person_ssim"=>["rob@notch8.com"],
   "nesting_collection__ancestors_ssim"=>["ww72bj826", "ww72bj826/h989rb20j"],
   "nesting_collection__parent_ids_ssim"=>["h989rb20j"],
   "nesting_collection__pathnames_ssim"=>["ww72bj826/h989rb20j/gh93hf179"],
   "nesting_collection__deepest_nested_depth_isi"=>3,
   "_version_"=>1754041471453888512,
   "timestamp"=>"2023-01-03T22:18:21.236Z"}
```
</details>

# expected behavior
create a rake task to update the thumbnail value of all works in the db. for good measure, I also added a rake task that updates only works that were imported in a specific bulkrax importer

``` sh
rake atla:update_all_thumbnail_paths
rake atla:update_thumbnail_paths_per_bulkrax_importer[bulkrax_id]
rake atla:update_thumbnail_path_for_one_work[work_id]
```

# testing instructions
1. find a work that has a thumbnail
2. remove the thumbnail
    ``` sh
    # bash into the container (docker compose exec web bash)
    # get into the rails console (rails c)
    w = Work.find <id of the work you found above>
    # e.g. w = Work.find '12345'
    w.thumbnail = nil
    w.save
    ```
3. run the rake task to bring the thumbnail back
    ``` sh
    # exit the rails console by typing "exit"
    rake atla:update_thumbnail_path_for_one_work[id of the work you found above]
    # e.g. rake atla:update_thumbnail_path_for_one_work[12345]
    ```