### PR TITLE
Remove bagit parser

### DIFF
--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -7,6 +7,10 @@ Bulkrax.setup do |config|
     { name: 'CDRI Xml File', class_name: 'Bulkrax::CdriParser', partial: 'cdri_fields' }
   ]
 
+  config.parsers -= [
+    { name: "Bagit", class_name: "Bulkrax::BagitParser", partial: "bagit_fields" }
+  ]
+
   config.default_work_type = 'Work'
 
   # Field to use during import to identify if the Work or Collection already exists.


### PR DESCRIPTION
# Summary
the option for the bagit parser should be removed

# Screenshot
<img width="1091" alt="image" src="https://user-images.githubusercontent.com/73361970/232622055-cd4384f7-3921-4966-8d1e-cfb2c99d8c0c.png">

# Related 
#267 

# Acceptance Criteria
- [ ] As a user, I should not see Bagit as an option in the bulkrax importers & exporters
