### PR TITLE
Include bulkrax collections in edit work form collection dropdown

### DIFF
--- a/app/views/hyrax/base/_form_member_of_collections.html.erb
+++ b/app/views/hyrax/base/_form_member_of_collections.html.erb
@@ -16,6 +16,7 @@ HTML Properties:
 <div class="form-group" data-behavior="collection-relationships" data-param-key="<%= f.object.model_name.param_key %>" data-members="<%= f.object.member_of_collections_json %>">
   <div class="form-inline">
       <%= f.label :member_of_collection_ids %>
+      <%# OVERRIDE Hyrax here to change the autocomplete-url and include all collections %>
       <%= f.input_field :member_of_collection_ids,
                   prompt: :translate,
                   data: {

--- a/app/views/hyrax/base/_form_member_of_collections.html.erb
+++ b/app/views/hyrax/base/_form_member_of_collections.html.erb
@@ -1,0 +1,47 @@
+<%# OVERRIDE Hyrax 2.6.0 to include bulkrax collections in the dropdown in the work/edit form relationships tab %>
+
+<%# Form UI behavior code and details;
+Code:
+  app/assets/javascripts/hyrax/relationships
+CSS:
+  [data-behavior="remove-relationship"] : Button to remove its parent TR from the table
+  [data-behavior="add-relationship"] : Button to clone its parent TR and inject a new row into the table
+  .message.has-warning : Used to display UI errors related to input values and server errors
+HTML Properties:
+  table:
+    [data-behavior="child-relationships"] : allows the javascript to be initialized
+    data-param-key : the parameter key value for this model type %>
+<h2><%= t("hyrax.works.form.in_collections") %></h2>
+
+<div class="form-group" data-behavior="collection-relationships" data-param-key="<%= f.object.model_name.param_key %>" data-members="<%= f.object.member_of_collections_json %>">
+<%#= raise 'hell' %>
+  <div class="form-inline">
+      <%= f.label :member_of_collection_ids %>
+      <%= f.input_field :member_of_collection_ids,
+                  prompt: :translate,
+                  data: {
+                    autocomplete: 'collection',
+                    'autocomplete-url' => Rails.application.routes.url_helpers.qa_path + '/search/collections'
+                  } %>
+      <a class="btn btn-primary" data-behavior="add-relationship">Add</a>
+  </div>
+
+  <table class="table table-striped">
+    <caption><%= t('.caption') %></caption>
+    <thead>
+    <tr>
+      <th><%= t('.header.title') %></th>
+      <th><%= t('.header.actions') %></th>
+    </tr>
+    </thead>
+    <tbody>
+    </tbody>
+  </table>
+</div>
+
+<script type="text/x-tmpl" id="tmpl-collection">
+<tr>
+  <td>{%= o.title %}</td>
+  <td><button class="btn btn-danger" data-behavior="remove-relationship" data-confirm-text="<%= t('.confirm.text') %>" data-confirm-cancel="<%= t('.confirm.cancel') %>" data-confirm-remove="<%= t('.confirm.remove') %>"><%= t('.actions.remove') %></button></td>
+</tr>
+</script>

--- a/app/views/hyrax/base/_form_member_of_collections.html.erb
+++ b/app/views/hyrax/base/_form_member_of_collections.html.erb
@@ -14,7 +14,6 @@ HTML Properties:
 <h2><%= t("hyrax.works.form.in_collections") %></h2>
 
 <div class="form-group" data-behavior="collection-relationships" data-param-key="<%= f.object.model_name.param_key %>" data-members="<%= f.object.member_of_collections_json %>">
-<%#= raise 'hell' %>
   <div class="form-inline">
       <%= f.label :member_of_collection_ids %>
       <%= f.input_field :member_of_collection_ids,


### PR DESCRIPTION
# Summary
In the edit work form "Relationships" tab, users can add a work to a collection via a dropdown. Before this PR, users were unable to see collections in the dropdown that were added in bulkrax.

After this PR is merged, users will be able to see all collections in the collection dropdown.

# Related 
#94 
#176 (duplicate)

# Video
https://share.getcloudapp.com/2NubWd9d

# Notes
Needs discussion about bulkrax: this PR overrides a view to change a path in the dropdown from showing collections with `access=deposit`, to all collections. 

This is the only change that is made in the overridden view (line 19):

```
      <%= f.input_field :member_of_collection_ids,
                  prompt: :translate,
                  data: {
                    autocomplete: 'collection',
                    'autocomplete-url' => Rails.application.routes.url_helpers.qa_path + '/search/collections?access=deposit'
                  } %>
```

becomes

```
      <%= f.input_field :member_of_collection_ids,
                  prompt: :translate,
                  data: {
                    autocomplete: 'collection',
                    'autocomplete-url' => Rails.application.routes.url_helpers.qa_path + '/search/collections'
                  } %>
```

This fix works for now for atla's purposes, but it seems like something may need to be changed in Bulkrax to give all collections being created `access=deposit`. Or maybe spreadsheets need to be changed/things need to be mapped so that `access=deposit` by default with bulkrax collections? It seems like it could get complicated though if only certain users have deposit access. 

Or, is this work sufficient and its just that now the view matches the work that has been done on https://github.com/scientist-softserv/atla_digital_library/issues/176 ?
