### PR TITLE
schema-woes

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,7 +40,6 @@ ActiveRecord::Schema.define(version: 20220609001128) do
     t.datetime "last_succeeded_at"
     t.string "importerexporter_type", default: "Bulkrax::Importer"
     t.integer "import_attempts", default: 0
-    t.index ["importerexporter_id"], name: "index_bulkrax_entries_on_importerexporter_id"
   end
 
   create_table "bulkrax_exporter_runs", force: :cascade do |t|
@@ -96,8 +95,6 @@ ActiveRecord::Schema.define(version: 20220609001128) do
     t.integer "total_file_set_entries", default: 0
     t.integer "processed_works", default: 0
     t.integer "failed_works", default: 0
-    t.integer "processed_children", default: 0
-    t.integer "failed_children", default: 0
     t.index ["importer_id"], name: "index_bulkrax_importer_runs_on_importer_id"
   end
 


### PR DESCRIPTION
## Story
When I rebuild from main with `dc down -v` and `dc build --no-cache`, aka a super fresh install besides recloning in a new directory. I am consistently getting this updated schema that removes: https://github.com/scientist-softserv/atla_digital_library/compare/main...schema-woes, taking a look at Bulkrax v4.4.1 I see these migrations:
Removes the foreign key, remove_foreign_key :bulkrax_entries, column: :importer_id https://github.com/samvera-labs/bulkrax/blob/v4.4.1/db/migrate/20190731114016_change_importer_and_exporter_to_polymorphic.rb#L10
Rename  processed_children to processed_relationships && failed_children to failed_relationships https://github.com/samvera-labs/bulkrax/blob/v4.4.1/db/migrate/20211203195233_rename_children_counters_to_relationships.rb

Conversation context in slack: https://assaydepot.slack.com/archives/C03B6A93E31/p1681940906108839