### PR TITLE
280 oai importing

### DIFF
--- a/app/models/bulkrax/oai_ia_entry.rb
+++ b/app/models/bulkrax/oai_ia_entry.rb
@@ -25,12 +25,14 @@ module Bulkrax
     end
 
     # OVERRIDE: v4.4.2 Bulkrax::ImportBehavior#add_collections
+    # rubocop:disable Style/RedundantSelf
     def add_collections
-      return if find_collection_ids.blank?
+      return if self.find_collection_ids.blank?
 
       # we need this mapping to exist so that Bulkrax::ImportBehavior#build_for_importer calls #parent_jobs
-      parsed_metadata[related_parents_parsed_mapping] = find_collection_ids
+      self.parsed_metadata[related_parents_parsed_mapping] = self.find_collection_ids
     end
+    # rubocop:enable Style/RedundantSelf
 
     def build_manifest
       url = "https://iiif.archivelab.org/iiif/#{record.header.identifier.split(':').last}/manifest.json"

--- a/app/models/bulkrax/oai_ia_entry.rb
+++ b/app/models/bulkrax/oai_ia_entry.rb
@@ -3,7 +3,6 @@ module Bulkrax
     def build_metadata
       self.parsed_metadata = {}
       parsed_metadata[work_identifier] = [record.header.identifier]
-      parent_collection = 'member_of_collections_attributes'
 
       record.metadata.children.each do |child|
         child.children.each do |node|
@@ -14,7 +13,6 @@ module Bulkrax
 
       parsed_metadata['contributing_institution'] = [contributing_institution]
       parsed_metadata['remote_manifest_url'] ||= build_manifest
-      parsed_metadata['parents'] = parse_parents(parsed_metadata[parent_collection]) if parsed_metadata[parent_collection]
 
       add_visibility
       add_rights_statement
@@ -26,8 +24,12 @@ module Bulkrax
       parsed_metadata
     end
 
-    def parse_parents(data)
-      data&.values&.pluck('id')
+    # OVERRIDE: v4.4.2 Bulkrax::ImportBehavior#add_collections
+    def add_collections
+      return if self.find_collection_ids.blank?
+
+      # we need this mapping to exist so that Bulkrax::ImportBehavior#build_for_importer calls #parent_jobs
+      self.parsed_metadata[related_parents_parsed_mapping] = self.find_collection_ids
     end
 
     def build_manifest

--- a/app/models/bulkrax/oai_ia_entry.rb
+++ b/app/models/bulkrax/oai_ia_entry.rb
@@ -3,6 +3,7 @@ module Bulkrax
     def build_metadata
       self.parsed_metadata = {}
       parsed_metadata[work_identifier] = [record.header.identifier]
+      parent_collection = 'member_of_collections_attributes'
 
       record.metadata.children.each do |child|
         child.children.each do |node|
@@ -13,6 +14,7 @@ module Bulkrax
 
       parsed_metadata['contributing_institution'] = [contributing_institution]
       parsed_metadata['remote_manifest_url'] ||= build_manifest
+      parsed_metadata['parents'] = parse_parents(parsed_metadata[parent_collection]) if parsed_metadata[parent_collection]
 
       add_visibility
       add_rights_statement
@@ -22,6 +24,10 @@ module Bulkrax
       parsed_metadata['contributor'] = nil
 
       parsed_metadata
+    end
+
+    def parse_parents(data)
+      data&.values&.pluck('id')
     end
 
     def build_manifest

--- a/app/models/bulkrax/oai_ia_entry.rb
+++ b/app/models/bulkrax/oai_ia_entry.rb
@@ -26,10 +26,10 @@ module Bulkrax
 
     # OVERRIDE: v4.4.2 Bulkrax::ImportBehavior#add_collections
     def add_collections
-      return if self.find_collection_ids.blank?
+      return if find_collection_ids.blank?
 
       # we need this mapping to exist so that Bulkrax::ImportBehavior#build_for_importer calls #parent_jobs
-      self.parsed_metadata[related_parents_parsed_mapping] = self.find_collection_ids
+      parsed_metadata[related_parents_parsed_mapping] = find_collection_ids
     end
 
     def build_manifest

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -50,7 +50,7 @@ Bulkrax.setup do |config|
       "title" => { from: ["title"] },
       "types" => { from: ["type"], split: /\s*[;]\s*/, parsed: true },
       "remote_files" => { from: ['thumbnail_url'], parsed: true },
-      'parents' => { from: ['parents'], related_parents_field_mapping: true },
+      'parents' => { from: ['member_of_collections_attributes'], related_parents_field_mapping: true },
       'children' => { from: ['children'], related_children_field_mapping: true }
     },
     "Bulkrax::CdriParser" => {

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -50,8 +50,6 @@ Bulkrax.setup do |config|
       "title" => { from: ["title"] },
       "types" => { from: ["type"], split: /\s*[;]\s*/, parsed: true },
       "remote_files" => { from: ['thumbnail_url'], parsed: true },
-      'parents' => { from: ['member_of_collections_attributes'], related_parents_field_mapping: true },
-      'children' => { from: ['children'], related_children_field_mapping: true }
     },
     "Bulkrax::CdriParser" => {
       "contributing_institution" => {from: ['publisher'] },


### PR DESCRIPTION
co-author: @summer-cook 

# Story
we need to be able to add works to collections when using the OAI IA parser. (sample feed used while testing, with a limit of 5: https://archive.org/services/oai.php?verb=ListRecords&metadataPrefix=oai_dc&set=collection:bibliotecadigitalanabautista)

this change also relies on: https://github.com/samvera-labs/bulkrax/pull/800

# Expected Behavior Before Changes
- works and collections were made, but not related to each other

# Expected Behavior After Changes
- works and collections are made, and related to each other

# Screenshots / Video

<details>
<summary>works imported</summary>

![image](https://user-images.githubusercontent.com/29032869/234433904-a7a3aa62-3ae6-4c0b-90b9-4442ec611a9d.png)
</details>

<details>
<summary>collections imported</summary>

![image](https://user-images.githubusercontent.com/29032869/234433984-3e2472c3-4dba-4a8f-8976-f1a03ce21f68.png)
</details>

<details>
<summary>works in collection</summary>

![image](https://user-images.githubusercontent.com/29032869/234434048-6e0ed72d-7033-4053-8aba-5bc39bbabb7d.png)
</details>