### PR TITLE
temporarily use the bulkrax branch "v4.4-patch"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,9 @@ gem 'rails', '5.1.6'
 
 gem 'activejob-scheduler', git: 'https://github.com/notch8/activejob-scheduler.git'
 gem 'blacklight_range_limit'
-gem 'bulkrax', '~> 4.4.0'
+# TODO: do a new release and use the versioned version of bulkrax when the upgrade work is complete
+gem 'bulkrax', git: 'https://github.com/samvera-labs/bulkrax.git', branch: 'v4.4-patch'
+# gem 'bulkrax', '~> 4.4.0'
 gem 'activerecord-nulldb-adapter'
 gem 'bixby', group: %i[development test]
 gem 'byebug', group: %i[development test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,26 @@ GIT
       rubyzip (>= 1.0.0)
 
 GIT
+  remote: https://github.com/samvera-labs/bulkrax.git
+  revision: 3b05129d8423c15f02f2e8364e5028af587bc58e
+  branch: v4.4-patch
+  specs:
+    bulkrax (4.4.2)
+      bagit (~> 0.4)
+      coderay
+      iso8601 (~> 0.9.0)
+      kaminari
+      language_list (~> 1.2, >= 1.2.1)
+      libxml-ruby (~> 3.1.0)
+      loofah (>= 2.2.3)
+      oai (>= 0.4, < 2.x)
+      rack (>= 2.0.6)
+      rails (>= 5.1.6)
+      rdf (>= 2.0.2, < 4.0)
+      rubyzip
+      simple_form
+
+GIT
   remote: https://github.com/samvera-labs/hyrax-iiif_av.git
   revision: 7066aef23c6f7dec0c19626a480a79899b5cf1fb
   branch: uv_meet_av
@@ -211,20 +231,6 @@ GEM
       thor (~> 0.19)
       typhoeus
     builder (3.2.4)
-    bulkrax (4.4.2)
-      bagit (~> 0.4)
-      coderay
-      iso8601 (~> 0.9.0)
-      kaminari
-      language_list (~> 1.2, >= 1.2.1)
-      libxml-ruby (~> 3.1.0)
-      loofah (>= 2.2.3)
-      oai (>= 0.4, < 2.x)
-      rack (>= 2.0.6)
-      rails (>= 5.1.6)
-      rdf (>= 2.0.2, < 4.0)
-      rubyzip
-      simple_form
     byebug (10.0.2)
     cancancan (1.17.0)
     capybara (2.18.0)
@@ -1003,7 +1009,7 @@ DEPENDENCIES
   activerecord-nulldb-adapter
   bixby
   blacklight_range_limit
-  bulkrax (~> 4.4.0)
+  bulkrax!
   byebug
   capybara (~> 2.13)
   coffee-rails (~> 4.2)


### PR DESCRIPTION
# Story
we've already done 2 patch releases of `v4.4.x` since beginning this bulkrax upgrade work. there's now [another update](https://github.com/samvera-labs/bulkrax/pull/800) that will need to be released as part of the bulkrax upgrade. instead of continuing to make releases, I propose we point at this branch which has all of our updates in it until all of the bugs are worked out.

once we complete all the work for the bulkrax upgrade, we can make another release and point towards it again.