### PR TITLE
i286-resolve-pipeline-build-error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM ruby:2.5.3 as hyrax-base
 
-RUN apt-get update -qq && \
+RUN echo "deb http://archive.debian.org/debian/ stretch main" > /etc/apt/sources.list && \
+    echo "deb http://archive.debian.org/debian-security/ stretch/updates main" >> /etc/apt/sources.list && \
+    apt-get update -qq && \
     apt-get -y install apt-transport-https && \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,6 @@ x-app: &app
   build:
     context: .
     target: hyrax-base
-    cache_from:
-        - ghcr.io/scientist-softserv/atla_digital_library:${TAG:-latest}
   # command: sh -l -c "bundle && bundle exec puma -v -b tcp://0.0.0.0:3000"
   image: ghcr.io/scientist-softserv/atla_digital_library:${TAG:-latest}
   env_file:


### PR DESCRIPTION
Updating the dockerfile to include the docker dependancies for debian stretch after stretch was archived and the url needs updating in the dependancies resulting in getting a failed build.

# Story
Receiving a build error in ci and locally after a dc build --no-cache
```sh
ERROR [hyrax-base  2/16] RUN apt-get update -qq &&     apt-get -y install apt-transport-https &&     curl -sS https://dl.yarnpkg.com/debian/pu  0.7s
------
 > [hyrax-base  2/16] RUN apt-get update -qq &&     apt-get -y install apt-transport-https &&     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - &&     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list &&     curl -sL https://deb.nodesource.com/setup_8.x | bash - &&     apt-get update -qq &&     apt-get install -y       build-essential       cmake       exiftool       ffmpeg       ghostscript       imagemagick       libpq-dev       libreoffice       libvips-dev       netcat       nodejs       screen       unzip       vim       yarn       zip       &&     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* &&     yarn config set no-progress &&     yarn config set silent:
#0 0.658 W: The repository 'http://security.debian.org/debian-security stretch/updates Release' does not have a Release file.
#0 0.658 W: The repository 'http://deb.debian.org/debian stretch Release' does not have a Release file.
#0 0.658 W: The repository 'http://deb.debian.org/debian stretch-updates Release' does not have a Release file.
#0 0.658 E: Failed to fetch http://security.debian.org/debian-security/dists/stretch/updates/main/binary-arm64/Packages  404  Not Found
#0 0.658 E: Failed to fetch http://deb.debian.org/debian/dists/stretch/main/binary-arm64/Packages  404  Not Found
#0 0.658 E: Failed to fetch http://deb.debian.org/debian/dists/stretch-updates/main/binary-arm64/Packages  404  Not Found
#0 0.658 E: Some index files failed to download. They have been ignored, or old ones used instead.
------
failed to solve: process "/bin/sh -c apt-get update -qq &&     apt-get -y install apt-transport-https &&     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - &&     echo \"deb https://dl.yarnpkg.com/debian/ stable main\" | tee /etc/apt/sources.list.d/yarn.list &&     curl -sL https://deb.nodesource.com/setup_8.x | bash - &&     apt-get update -qq &&     apt-get install -y       build-essential       cmake       exiftool       ffmpeg       ghostscript       imagemagick       libpq-dev       libreoffice       libvips-dev       netcat       nodejs       screen       unzip       vim       yarn       zip       &&     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* &&     yarn config set no-progress &&     yarn config set silent" did not complete successfully: exit code: 100
```
Refs #issuenumber

# Expected Behavior Before Changes
CI and local builds fail

# Expected Behavior After Changes
CI and local builds succeed
