### PR TITLE
280-all-oai-imports

### DIFF
--- a/app/models/bulkrax/oai_dc_entry.rb
+++ b/app/models/bulkrax/oai_dc_entry.rb
@@ -4,5 +4,13 @@ module Bulkrax
     def self.matcher_class
       Bulkrax::AtlaOaiMatcher
     end
+
+    # OVERRIDE: v4.4.2 Bulkrax::ImportBehavior#add_collections
+    def add_collections
+      return if self.find_collection_ids.blank?
+
+      # we need this mapping to exist so that Bulkrax::ImportBehavior#build_for_importer calls #parent_jobs
+      self.parsed_metadata[related_parents_parsed_mapping] = self.find_collection_ids
+    end
   end
 end

--- a/app/models/bulkrax/oai_ia_entry.rb
+++ b/app/models/bulkrax/oai_ia_entry.rb
@@ -24,14 +24,6 @@ module Bulkrax
       parsed_metadata
     end
 
-    # OVERRIDE: v4.4.2 Bulkrax::ImportBehavior#add_collections
-    def add_collections
-      return if self.find_collection_ids.blank?
-
-      # we need this mapping to exist so that Bulkrax::ImportBehavior#build_for_importer calls #parent_jobs
-      self.parsed_metadata[related_parents_parsed_mapping] = self.find_collection_ids
-    end
-
     def build_manifest
       url = "https://iiif.archivelab.org/iiif/#{record.header.identifier.split(':').last}/manifest.json"
       return [url] if manifest_available?(url)


### PR DESCRIPTION
Refs:
- #280 

# Expected Behavior Before Changes
- works were only related to collections through the OaiIaParser

# Expected Behavior After Changes
- move the `Bulkrax::ImportBehavior#add_collections override` from OaiIaEntry to OaiDcEntry
- works are related to collections in all Oai parsers

# Screenshots / Video
<img width="781" alt="image" src="https://user-images.githubusercontent.com/29032869/235775264-e7d3c17e-2c3a-472b-9d45-244e943352b4.png">