### PR TITLE
240 restore exporting

### DIFF
--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -50,6 +50,8 @@ Bulkrax.setup do |config|
       "title" => { from: ["title"] },
       "types" => { from: ["type"], split: /\s*[;]\s*/, parsed: true },
       "remote_files" => { from: ['thumbnail_url'], parsed: true },
+      'parents' => { from: ['parents'], related_parents_field_mapping: true },
+      'children' => { from: ['children'], related_children_field_mapping: true }
     },
     "Bulkrax::CdriParser" => {
       "contributing_institution" => {from: ['publisher'] },


### PR DESCRIPTION
co-author: @labradford 

# Story
we need to be able to export.

return the parent and children mappings that lea ann added on #263 and I removed on #282 before understanding that all parsers use the OaiDcParser mappings. will refactor in a different pr

Refs
- #240 

# Screenshots / Video
[export_1_3_1.zip](https://github.com/scientist-softserv/atla_digital_library/files/11384732/export_1_3_1.zip)

![image](https://user-images.githubusercontent.com/29032869/235977639-1a7f7cf5-f098-4e76-8f82-6de1630498f9.png)