### PR TITLE
Update the collection dropdown on work show page

### DIFF
--- a/app/views/hyrax/dashboard/collections/_form_for_select_collection.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_for_select_collection.html.erb
@@ -1,0 +1,50 @@
+<%# OVERRIDE Hyrax 2.6.0 to include bulkrax collections in the dropdown on the work/show page %>
+
+<div role="dialog" class="modal collection-list-modal fade" id="collection-list-container" tabindex="-1" aria-labelledby="col_add_title">
+  <div class="modal-dialog text-left">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+          <span class="modal-title" id="col_add_title"><%= t("hyrax.collection.select_form.title") %></span>
+        </div>
+        <div class="modal-body">
+          <% if user_collections.blank? %>
+            <em> <%= t("hyrax.collection.select_form.no_collections") %></em><br /><br /><br /><br />
+          <% else %>
+            <div class="collection-list">
+              <fieldset>
+                <legend><%= t("hyrax.collection.select_form.select_heading") %></legend>
+                <ul>
+                  <% if @add_works_to_collection.present? %>
+                    <%= text_field_tag 'member_of_collection_label', @add_works_to_collection_label, disabled: true %>
+                    <%= hidden_field_tag 'member_of_collection_ids', @add_works_to_collection %>
+                  <% else %>
+                    <%# OVERRIDE Hyrax 2.6.0 here. removes the permissions on add to collection button. %>
+                    <%= text_field_tag 'member_of_collection_ids',
+                                        nil,
+                                        prompt: :translate,
+                                        data: {
+                                          placeholder: t('simple_form.placeholders.defaults.member_of_collection_ids'),
+                                          autocomplete: 'collection',
+                                          'autocomplete-url' => Rails.application.routes.url_helpers.qa_path + '/search/collections?access=deposit'
+                                        } %>
+                  <% end %>
+                </ul>
+              </fieldset>
+            </div><!-- collection-list -->
+          <% end %> <!-- else -->
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal"><%= t("hyrax.collection.select_form.close") %></button>
+          <% if user_collections.blank? %>
+              <% # TODO: Uncomment the following line when errors with adding works to a new collection are resolved.  See Issue hyrax#3088 %>
+              <% # = render 'hyrax/dashboard/collections/button_create_collection', label: t("hyrax.collection.select_form.create") %>
+          <% else %>
+            <%= render 'hyrax/dashboard/collections/button_for_update_collection', label: t("hyrax.collection.select_form.update"), collection_id: 'collection_replace_id' %>
+            <% # TODO: Uncomment the following line when errors with adding works to a new collection are resolved.  See Issue hyrax#3088 %>
+            <% # = render 'hyrax/dashboard/collections/button_create_collection', label: t("hyrax.collection.select_form.create_new") %>
+          <% end %>
+        </div>
+      </div><!-- /.modal-content -->
+  </div><!-- /.modal-dialog -->
+</div><!-- /.modal -->


### PR DESCRIPTION
# Summary
From the work-show page, users can add a work to a collection via a dropdown. Before this PR, users were unable to see collections in the dropdown that were added in bulkrax.

After this PR is merged, users will be able to see all collections in the collection dropdown.

# Related 

- #94 
- #176 (duplicate)
- previous pr for dashboard: https://github.com/scientist-softserv/atla_digital_library/pull/271

# Notes
The FULL first word of the collection must be typed in. This is a known bug in hyrax.