### PR TITLE
EXPERIMENTAL: fix-mixed-media-uv-issue

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = false
+  config.force_ssl = true
   config.ssl_options = { hsts: { expires: 365.days, subdomains: true } }
 
   # Use the lowest log level to ensure availability of diagnostic information


### PR DESCRIPTION
Experimental to update config ssl = true in production.

Based on this previous [PR](https://github.com/scientist-softserv/atla_digital_library/commit/231665373de7c9d9b9f8315422fd8c9e394a3de8) from Rob, changing this may break production, but we need to troubleshoot with this on a branch deploy to test in production as not staging testable as dns config is different in production.

In production client states CDRI uv is not showing. After navigating to a cdri collection work with a moving image, https://dl.atla.com/concern/works/5999nm77k and was able to see errors in the console about mixed media types http:// & https://. If you review the [manifest](https://dl.atla.com/concern/works/5999nm77k/manifest), you can see the urls are not https:// and they need to be in order for the uv to loads the works.

<details><summary>CLICK ME Screenshot</summary>
<img width="1352" alt="Screenshot 2023-09-25 at 18 11 13" src="https://github.com/scientist-softserv/atla_digital_library/assets/63515648/46ab8614-deed-486d-8f56-c670607a7314">
<img width="1291" alt="Screenshot 2023-09-25 at 21 11 26" src="https://github.com/scientist-softserv/atla_digital_library/assets/63515648/3b36a250-9bad-4cd9-9f11-c00d7bec3871">



</details>