### PR TITLE
Description field character limit

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -112,7 +112,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("creator", :stored_searchable), label: "Creator", itemprop: 'creator', link_to_search: solr_name("creator", :facetable)
     config.add_index_field solr_name("date", :stored_searchable), label: "Date", itemprop: 'dateCreated', link_to_search: solr_name("date", :facetable)
     config.add_index_field solr_name("contributing_institution", :stored_searchable), label: "Contributing Institution", itemprop: 'contributingInstitution', link_to_search: solr_name("contributing_institution", :facetable)
-    config.add_index_field solr_name("description", :stored_searchable), label: "Description", itemprop: 'description', helper_method: :iconify_auto_link
+    config.add_index_field solr_name("description", :stored_searchable), label: "Description", itemprop: 'description', helper_method: :index_filter
     # config.add_index_field solr_name("subject", :stored_searchable), label: "Subject", itemprop: 'about', link_to_search: solr_name("subject", :facetable)
     # config.add_index_field solr_name("place", :symbol), label: "Place", helper_method: :link_to_profile, link_to_search: solr_name("place", :facetable)
     # config.add_index_field solr_name("contributor", :stored_searchable), label: "Contributor", itemprop: 'contributor', link_to_search: solr_name("contributor", :facetable)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -112,7 +112,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("creator", :stored_searchable), label: "Creator", itemprop: 'creator', link_to_search: solr_name("creator", :facetable)
     config.add_index_field solr_name("date", :stored_searchable), label: "Date", itemprop: 'dateCreated', link_to_search: solr_name("date", :facetable)
     config.add_index_field solr_name("contributing_institution", :stored_searchable), label: "Contributing Institution", itemprop: 'contributingInstitution', link_to_search: solr_name("contributing_institution", :facetable)
-    config.add_index_field solr_name("description", :stored_searchable), label: "Description", itemprop: 'description', helper_method: :index_filter
+    config.add_index_field solr_name("description", :stored_searchable), label: "Description", itemprop: 'description', helper_method: :truncate_text
     # config.add_index_field solr_name("subject", :stored_searchable), label: "Subject", itemprop: 'about', link_to_search: solr_name("subject", :facetable)
     # config.add_index_field solr_name("place", :symbol), label: "Place", helper_method: :link_to_profile, link_to_search: solr_name("place", :facetable)
     # config.add_index_field solr_name("contributor", :stored_searchable), label: "Contributor", itemprop: 'contributor', link_to_search: solr_name("contributor", :facetable)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -67,9 +67,7 @@ module ApplicationHelper
     has_iiif? ? 'col-sm-7' : 'col-sm-9'
   end
 
-  # rubocop:disable Rails/OutputSafety
-  def index_filter(options = {})
-    options[:value][0].truncate(300).to_s.html_safe
+  def truncate_text(options = {})
+    options[:value][0].truncate(300)
   end
-  # rubocop:enable Rails/OutputSafety
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -66,4 +66,10 @@ module ApplicationHelper
   def show_main_size
     has_iiif? ? 'col-sm-7' : 'col-sm-9'
   end
+
+  # rubocop:disable Rails/OutputSafety
+  def index_filter(options = {})
+    options[:value][0].truncate(300).to_s.html_safe
+  end
+  # rubocop:enable Rails/OutputSafety
 end


### PR DESCRIPTION

# Story
I added a helper method (grabbed from hyku) to limit the character length of the description field that shows in the search results page.

Refs #issuenumber

# Expected Behavior Before Changes

# Expected Behavior After Changes

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes