### PR TITLE
i330-add-tls-to-ingress

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -57,9 +57,6 @@ extraVolumeMounts: &volMounts
 ingress:
   enabled: true
   hosts:
-    - host: atla.notch8.cloud
-      paths:
-        - path: /
     - host: dl.atla.com
       paths:
         - path: /
@@ -67,6 +64,10 @@ ingress:
     kubernetes.io/ingress.class: "nginx",
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
   }
+  tls:
+    - hosts:
+        - dl.atla.com
+      secretName: notch8cloud
 
 extraEnvVars: &envVars
   - name: CONFDIR


### PR DESCRIPTION
# Story
Add the tls to the ingress to fix security issues from the security scan
Remove old un-used dns atla.notch8.cloud

Refs #330 
